### PR TITLE
ci: inject app version during Docker build and set default config

### DIFF
--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -20,3 +20,5 @@ jobs:
         with:
           push: true
           tags: hilkopterbob/packagelock:latest
+          build-args: |
+            APP_VERSION=${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN go mod download
 
 
 # Build
-
-RUN CGO_ENABLED=0 GOOS=linux go build -o /packagelock
+ARG APP_VERSION="v0.1.0+hotfixes"
+RUN \
+  CGO_ENABLED=0 GOOS=linux go build -ldflags "-X 'main.AppVersion=$APP_VERSION'" -o /packagelock
 
 # Optional:
 # To bind to a TCP port, runtime parameters must be supplied to the docker command.

--- a/config/conf-init.go
+++ b/config/conf-init.go
@@ -20,6 +20,7 @@ type ConfigProvider interface {
 	ReadConfig(in io.Reader) error
 	AllSettings() map[string]any
 	GetString(string string) string
+	SetDefault(key string, value any)
 }
 
 // TODO: How to test?

--- a/main.go
+++ b/main.go
@@ -15,12 +15,20 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Data structs
+// Linker Injections
+// Version injection with Docker Build & ldflags
+// Do not modify, init or change in code!
+var AppVersion string
 
 // TODO: support for multiple network adapters.
 
 func main() {
 	Config := config.StartViper(viper.New())
+
+	if AppVersion != "" {
+		Config.SetDefault("general.app-version", AppVersion)
+	}
+
 	fmt.Println(Config.AllSettings())
 
 	// Channel to signal the restart


### PR DESCRIPTION
- Updated `github/workflows/build-docker-container.yml` to pass the app version as a build argument using the release tag name.- Modified `Dockerfile` to include `APP_VERSION` argument and inject it during the build process via `ldflags`.- Enhanced `ConfigProvider` in `conf-init.go` to set the default app version using the injected value.- Added `AppVersion` variable in `main.go` for linker injection, ensuring the version is set at runtime based on the Docker build process.