### PR TITLE
feat: log rotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,5 +56,6 @@ require (
 	golang.org/x/text v0.19.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/k0kubun/pp"
@@ -27,7 +26,6 @@ func NewLogger() (*zap.Logger, error) {
 		Compress:   true,           // Compress the rotated log files
 	}
 
-
 	// Encoder configuration
 	encoderConfig := zapcore.EncoderConfig{
 		TimeKey:        "timestamp",
@@ -41,7 +39,6 @@ func NewLogger() (*zap.Logger, error) {
 		EncodeTime:     zapcore.ISO8601TimeEncoder,
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
-
 	}
 
 	encoder := zapcore.NewConsoleEncoder(encoderConfig) // Use NewJSONEncoder for JSON logs

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // Module exports the logger module.
@@ -14,42 +15,61 @@ var Module = fx.Provide(NewLogger)
 
 // NewLogger constructs a new logger instance.
 func NewLogger() (*zap.Logger, error) {
-	InitLogger()
+	createLogDir()
 
-	// logger Config
-	loggerConfig := zap.Config{
-		Encoding:         "console", // You can also use "json"
-		OutputPaths:      []string{"logs/app.log"},
-		ErrorOutputPaths: []string{"logs/app_error.log"},
-		Level:            zap.NewAtomicLevelAt(zapcore.InfoLevel),
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "timestamp",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.CapitalLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.StringDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
-		},
+	// Initialize Lumberjack logger for log rotation
+	lumberjackLogger := &lumberjack.Logger{
+		Filename:   "logs/app.log", // Log file name
+		MaxSize:    250,            // Max size in MB before rotation
+		MaxBackups: 3,              // Max number of old log files to retain
+		MaxAge:     28,             // Max number of days to retain old log files
+		Compress:   true,           // Compress the rotated log files
 	}
-	// Build the logger
-	logger, err := loggerConfig.Build()
-	if err != nil {
-		// Handle logger initialization error (no panic)
-		logger = nil
-		panic(err)
+
+	// Encoder configuration
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
 	}
-	// Return the initialized logger and any error that occurred
+
+	encoder := zapcore.NewConsoleEncoder(encoderConfig) // Use NewJSONEncoder for JSON logs
+
+	// Create WriteSyncer for Lumberjack logger
+	fileWriter := zapcore.AddSync(lumberjackLogger)
+	consoleWriter := zapcore.AddSync(os.Stdout)
+	writeSyncer := zapcore.NewMultiWriteSyncer(fileWriter, consoleWriter)
+
+	logLevel := zapcore.InfoLevel
+
+	core := zapcore.NewCore(encoder, writeSyncer, logLevel)
+	logger := zap.New(core,
+		zap.AddCaller(),                       // Include caller information
+		zap.AddStacktrace(zapcore.ErrorLevel), // Include stacktrace for error-level logs
+	)
+
 	logger.Info("--------------------------------------------")
-	return logger, err
+	logger.Info("Logger initialized successfully")
+
+	go func(logger *zap.Logger) {
+		for {
+			logger.Info("Loop")
+		}
+	}(logger)
+
+	return logger, nil
 }
 
 // Creates to logs/ directory
-func InitLogger() {
+func createLogDir() {
 	err := os.MkdirAll("logs/", os.ModePerm)
 	if err != nil {
 		pp.Printf("Couldn't create 'logs' directory. Got: %s", err)


### PR DESCRIPTION
This implements Lumberjack, a well-known log rotation tool. Its current settings:
250 MB max size
3 Backups
max 28 days old
backups will be compressed (great because textfile with repeating messages)