### PR TITLE
Change: add nightly_release Workflow to default Branch

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -1,0 +1,68 @@
+name: Nightly Release
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Create Nightly Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with: 
+            ref: devel
+
+      - name: Set APP_VERSION
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION=${{ github.event.inputs.version }}
+          else
+            VERSION=${{ github.ref }}
+            VERSION=${VERSION#refs/tags/}
+          fi
+          echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Build Go Application
+        run: |
+          mkdir -p ${{ github.workspace }}/packagelock
+          APP_VERSION=${{ env.APP_VERSION }}
+          CGO_ENABLED=0 GOOS=linux go build -ldflags "-X 'main.AppVersion=$APP_VERSION'" -o ${{ github.workspace }}/packagelock
+
+      - name: Create Release Archive
+        run: |
+          mkdir -p release
+          cp -r ${{ github.workspace }}/packagelock ./release/packagelock
+          tar -czvf release/packagelock-${{ env.APP_VERSION }}-linux-amd64-nightly.tar.gz -C release packagelock
+
+      - name: Calculate Checksum
+        run: | 
+          md5sum ./release/packagelock-${{ env.APP_VERSION }}-linux-amd64-nightly.tar.gz | cut -f 1 -d " " > ./release/packagelock-${{ env.APP_VERSION }}-linux-amd64.tar.gz.md5
+
+      - name: Upload Release Tarball
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://api.github.com/repos/HilkopterBob/PackageLock/releases/180504390/assets
+          asset_path: ./release/packagelock-${{ env.APP_VERSION }}-linux-amd64-nightly.tar.gz
+          asset_name: packagelock-${{ env.APP_VERSION }}-linux-amd64-nightly.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Checksum
+        id: upload-checksum-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://api.github.com/repos/HilkopterBob/PackageLock/releases/180504390/assets
+          asset_path: ./release/packagelock-${{ env.APP_VERSION }}-linux-amd64-nightly.tar.gz.md5
+          asset_name: packagelock-${{ env.APP_VERSION }}-linux-amd64-nightly.tar.gz.md5
+          asset_content_type: text/plain


### PR DESCRIPTION
Githubs Cron Schedule only works on the default branch to address this, this pull request is being made.
Manualy triggering the workflow works only on default branch aswell